### PR TITLE
Fix "Cannot convert undefined to a BigInt"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ class D1Connection implements DatabaseConnection {
     }
 
     return {
-      insertId: !results.lastRowId ? undefined : BigInt(results.lastRowId),
+      insertId: !results.lastRowId ? results.lastRowId : BigInt(results.lastRowId),
       rows: (results?.results as O[]) || [],
       numUpdatedOrDeletedRows: results.changes > 0 ? BigInt(results.changes) : undefined,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ class D1Connection implements DatabaseConnection {
     }
 
     return {
-      insertId: results.lastRowId !== null ? BigInt(results.lastRowId) : undefined,
+      insertId: !results.lastRowId ? undefined : BigInt(results.lastRowId),
       rows: (results?.results as O[]) || [],
       numUpdatedOrDeletedRows: results.changes > 0 ? BigInt(results.changes) : undefined,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ class D1Connection implements DatabaseConnection {
     }
 
     return {
-      insertId: !results.lastRowId ? results.lastRowId : BigInt(results.lastRowId),
+      insertId: results.lastRowId === undefined || results.lastRowId === null ? undefined : BigInt(results.lastRowId),
       rows: (results?.results as O[]) || [],
       numUpdatedOrDeletedRows: results.changes > 0 ? BigInt(results.changes) : undefined,
     };


### PR DESCRIPTION
- [X] I have verified my changes didn't break the `example` project.

#### Description

I fixed the following exception when executing queries:


```
Uncaught (in promise) TypeError: Cannot convert undefined to a BigInt
  insertId: results.lastRowId !== null ? BigInt(results.lastRowId) : undefined,
                                         ^
      at executeQuery
```