### PR TITLE
Fix exception when lastRowId is `undefined`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ class D1Connection implements DatabaseConnection {
     }
 
     return {
-      insertId: results.lastRowId !== null ? BigInt(results.lastRowId) : undefined,
+      insertId: results.lastRowId != null ? BigInt(results.lastRowId) : undefined,
       rows: (results?.results as O[]) || [],
       numUpdatedOrDeletedRows: results.changes > 0 ? BigInt(results.changes) : undefined,
     };


### PR DESCRIPTION
- [x] I have verified my changes didn't break the `example` project.

#### Description
lastRowId can be undefined when using a custom primary key, which in turn results in an exception here (Cannot convert undefined to a BigInt)