### PR TITLE
0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kysely-d1",
   "description": "Kysely dialect for Cloudflare D1",
   "main": "./dist/index.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "types": "./dist/index.d.ts",
   "repository": "git@github.com:aidenwallis/kysely-d1.git",
   "author": "Aiden <aiden@aidenwallis.co.uk>",


### PR DESCRIPTION
- [x] I have verified my changes didn't break the `example` project.

#### Description

Release for 0.0.6, with the following changes:

* Point to public documentation for D1 in README (#11)
* Fix "Cannot convert undefined to a BigInt" (#8) - thank you @KernelFreeze!