### PR TITLE
add `numAffectedRows` @ `D1Connection.executeQuery`.

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,8 +8,8 @@
       "name": "fuck-wrangler",
       "version": "0.0.0",
       "dependencies": {
-        "kysely": "^0.22.0",
-        "kysely-d1": "^0.0.5"
+        "kysely": "^0.23.3",
+        "kysely-d1": "^0.0.6"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.17.0",
@@ -1005,17 +1005,17 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.22.0.tgz",
-      "integrity": "sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
+      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/kysely-d1": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.0.5.tgz",
-      "integrity": "sha512-cot0gORL2ZoNvsy+9jSeXKcKnoSTWLb+iZx73qoojD5z56mQ80rgcXwk2Rtg53sxAWyp9cM5TApQVL4wwpmQgA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.0.6.tgz",
+      "integrity": "sha512-WF0au/jHw/5ILirADKrDp/yGI/9rilRBqz0+/HIz61qSk6yDGF+DO5UXaDOw/w+q44s+HrYLTdQMlR/QSSTWtQ==",
       "peerDependencies": {
         "kysely": "*"
       }
@@ -2225,14 +2225,14 @@
       "dev": true
     },
     "kysely": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.22.0.tgz",
-      "integrity": "sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ=="
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
+      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA=="
     },
     "kysely-d1": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.0.5.tgz",
-      "integrity": "sha512-cot0gORL2ZoNvsy+9jSeXKcKnoSTWLb+iZx73qoojD5z56mQ80rgcXwk2Rtg53sxAWyp9cM5TApQVL4wwpmQgA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.0.6.tgz",
+      "integrity": "sha512-WF0au/jHw/5ILirADKrDp/yGI/9rilRBqz0+/HIz61qSk6yDGF+DO5UXaDOw/w+q44s+HrYLTdQMlR/QSSTWtQ==",
       "requires": {}
     },
     "lru-cache": {

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "deploy": "wrangler publish"
   },
   "dependencies": {
-    "kysely": "^0.22.0",
-    "kysely-d1": "^0.0.5"
+    "kysely": "^0.23.3",
+    "kysely-d1": "^0.0.6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "kysely-d1",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kysely-d1",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^3.17.0",
         "@tsconfig/node14": "^1.0.3",
-        "kysely": "^0.22.0",
+        "kysely": "^0.23.3",
         "prettier": "^2.7.1",
         "typescript": "^4.8.4"
       },
@@ -34,11 +34,10 @@
       "license": "MIT"
     },
     "node_modules/kysely": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.22.0.tgz",
-      "integrity": "sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
+      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -87,9 +86,9 @@
       "dev": true
     },
     "kysely": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.22.0.tgz",
-      "integrity": "sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
+      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA==",
       "dev": true
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^3.17.0",
     "@tsconfig/node14": "^1.0.3",
-    "kysely": "^0.22.0",
+    "kysely": "^0.23.3",
     "prettier": "^2.7.1",
     "typescript": "^4.8.4"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,10 +111,8 @@ class D1Connection implements DatabaseConnection {
     return {
       insertId: results.lastRowId === undefined || results.lastRowId === null ? undefined : BigInt(results.lastRowId),
       rows: (results?.results as O[]) || [],
-      // @ts-ignore replaces `QueryResult.numUpdatedOrDeletedRows` in kysely > 0.22
-      // following https://github.com/koskimas/kysely/pull/188
       numAffectedRows,
-      // deprecated in kysely > 0.22, keep for backward compatibility.
+      // @ts-ignore deprecated in kysely >= 0.23, keep for backward compatibility.
       numUpdatedOrDeletedRows: numAffectedRows,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,10 +106,16 @@ class D1Connection implements DatabaseConnection {
       throw new Error(results.error);
     }
 
+    const numAffectedRows = results.changes > 0 ? BigInt(results.changes) : undefined;
+
     return {
       insertId: results.lastRowId === undefined || results.lastRowId === null ? undefined : BigInt(results.lastRowId),
       rows: (results?.results as O[]) || [],
-      numUpdatedOrDeletedRows: results.changes > 0 ? BigInt(results.changes) : undefined,
+      // @ts-ignore replaces `QueryResult.numUpdatedOrDeletedRows` in kysely > 0.22
+      // following https://github.com/koskimas/kysely/pull/188
+      numAffectedRows,
+      // deprecated in kysely > 0.22, keep for backward compatibility.
+      numUpdatedOrDeletedRows: numAffectedRows,
     };
   }
 


### PR DESCRIPTION
- [x] I have verified my changes didn't break the `example` project.

Wrangler's inspector port is blocked on my wsl2 machine. 🤷 

#### Description

aligns with koskimas/kysely#188 (not released yet)

`QueryResult.numUpdatedOrDeletedRows` is being deprecated in next `kysely` release, and will be removed in the future. It is being replaced with `QueryResult.numAffectedRows` for reasons discussed in linked pull request.
