### PR TITLE
Add custom Introspector class to allow transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20230115.0",
         "@tsconfig/node14": "^1.0.3",
-        "kysely": "^0.23.3",
+        "kysely": "^0.26.3",
         "prettier": "^2.7.1",
         "typescript": "^4.8.4"
       },
@@ -33,9 +33,9 @@
       "license": "MIT"
     },
     "node_modules/kysely": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
-      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.26.3.tgz",
+      "integrity": "sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -85,9 +85,9 @@
       "dev": true
     },
     "kysely": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.23.3.tgz",
-      "integrity": "sha512-spRhosWRLkI0Ox8PRBdstskdRfvoLPsJ5GEpDA/PPrX6NwuiygdsFxHBrMkdU3CX+VxLhj4Wn5P7rFAwaf7JuA==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.26.3.tgz",
+      "integrity": "sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==",
       "dev": true
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230115.0",
     "@tsconfig/node14": "^1.0.3",
-    "kysely": "^0.23.3",
+    "kysely": "^0.26.3",
     "prettier": "^2.7.1",
     "typescript": "^4.8.4"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@ import {
   SqliteIntrospector,
   SqliteQueryCompiler,
   TableMetadata,
-} from "kysely";
-import type { D1Database } from "@cloudflare/workers-types";
+} from 'kysely';
+import type { D1Database } from '@cloudflare/workers-types';
 
 /**
  * Config for the D1 dialect. Pass your D1 instance to this object that you bound in `wrangler.toml`.
@@ -37,13 +37,8 @@ class D1Introspector extends SqliteIntrospector {
     this.#config = config;
   }
 
-  async #getTableMetadata(
-    name: string,
-    isView: boolean,
-  ): Promise<TableMetadata> {
-    const result = await this.#config.database.prepare(
-      `PRAGMA table_info(${name})`,
-    ).run();
+  async #getTableMetadata(name: string, isView: boolean): Promise<TableMetadata> {
+    const result = await this.#config.database.prepare(`PRAGMA table_info(${name})`).run();
     const rows = result.results as {
       name: string;
       type: string;
@@ -65,30 +60,21 @@ class D1Introspector extends SqliteIntrospector {
   }
 
   async getTables(options?: DatabaseMetadataOptions): Promise<TableMetadata[]> {
-    const result = await this.#config.database.prepare("PRAGMA table_list")
-      .run();
+    const result = await this.#config.database.prepare('PRAGMA table_list').run();
     // We filter out tables that start with "_cf_", as they are internal tables
     // which will cause errors when trying to introspect them.
     let tables = (
       result.results as {
         name: string;
-        type: "table" | "view";
+        type: 'table' | 'view';
       }[]
-    ).filter(({ name }) => !name.startsWith("_cf_"));
+    ).filter(({ name }) => !name.startsWith('_cf_'));
 
     if (!options?.withInternalKyselyTables) {
-      tables = tables.filter(
-        ({ name }) =>
-          name !== DEFAULT_MIGRATION_TABLE &&
-          name !== DEFAULT_MIGRATION_LOCK_TABLE,
-      );
+      tables = tables.filter(({ name }) => name !== DEFAULT_MIGRATION_TABLE && name !== DEFAULT_MIGRATION_LOCK_TABLE);
     }
 
-    return Promise.all(
-      tables.map(({ name, type }) =>
-        this.#getTableMetadata(name, type === "view")
-      ),
-    );
+    return Promise.all(tables.map(({ name, type }) => this.#getTableMetadata(name, type === 'view')));
   }
 }
 
@@ -179,15 +165,13 @@ class D1Connection implements DatabaseConnection {
       throw new Error(results.error);
     }
 
-    const numAffectedRows = results.meta.changes > 0
-      ? BigInt(results.meta.changes)
-      : undefined;
+    const numAffectedRows = results.meta.changes > 0 ? BigInt(results.meta.changes) : undefined;
 
     return {
-      insertId: results.meta.last_row_id === undefined ||
-          results.meta.last_row_id === null
-        ? undefined
-        : BigInt(results.meta.last_row_id),
+      insertId:
+        results.meta.last_row_id === undefined || results.meta.last_row_id === null
+          ? undefined
+          : BigInt(results.meta.last_row_id),
       rows: (results?.results as O[]) || [],
       numAffectedRows,
       // @ts-ignore deprecated in kysely >= 0.23, keep for backward compatibility.
@@ -198,27 +182,24 @@ class D1Connection implements DatabaseConnection {
   async beginTransaction() {
     // this.#transactionClient = this.#transactionClient ?? new PlanetScaleConnection(this.#config)
     // this.#transactionClient.#conn.execute('BEGIN')
-    throw new Error("Transactions are not supported yet.");
+    throw new Error('Transactions are not supported yet.');
   }
 
   async commitTransaction() {
     // if (!this.#transactionClient) throw new Error('No transaction to commit')
     // this.#transactionClient.#conn.execute('COMMIT')
     // this.#transactionClient = undefined
-    throw new Error("Transactions are not supported yet.");
+    throw new Error('Transactions are not supported yet.');
   }
 
   async rollbackTransaction() {
     // if (!this.#transactionClient) throw new Error('No transaction to rollback')
     // this.#transactionClient.#conn.execute('ROLLBACK')
     // this.#transactionClient = undefined
-    throw new Error("Transactions are not supported yet.");
+    throw new Error('Transactions are not supported yet.');
   }
 
-  async *streamQuery<O>(
-    _compiledQuery: CompiledQuery,
-    _chunkSize: number,
-  ): AsyncIterableIterator<QueryResult<O>> {
-    throw new Error("D1 Driver does not support streaming");
+  async *streamQuery<O>(_compiledQuery: CompiledQuery, _chunkSize: number): AsyncIterableIterator<QueryResult<O>> {
+    throw new Error('D1 Driver does not support streaming');
   }
 }


### PR DESCRIPTION
- [x] I have verified my changes didn't break the `example` project.

#### Description

This dialect used the built-in Kysely `SqliteIntrospector` class as its introspector, which under the hood makes queries to the `sqlite_master` table, which in D1 is a no go - I've extended `SqliteIntrospector` into a `D1Introspector` to support using the `table_list` and `table_info` `PRAGMA`s to query table metadata instead.

Also, I've bumped up the version of `kysely` to the latest while I'm here as there were type discrepancies between `0.23.3` and `0.26.3`.