### PR TITLE
Distribute package as both ESM and CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
   "name": "kysely-d1",
   "description": "Kysely dialect for Cloudflare D1",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "version": "0.3.0",
   "types": "./dist/index.d.ts",
   "repository": "git@github.com:aidenwallis/kysely-d1.git",
   "author": "Aiden <aiden@aidenwallis.co.uk>",
   "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -18,7 +26,7 @@
     "serverless"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cjs.json && mv dist/cjs/index.js dist/index.cjs && rmdir dist/cjs",
     "check": "prettier --check src/ example/",
     "format": "prettier --write src/ example/"
   },

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/cjs",
+    "declaration": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
+    "module": "ESNext",
     "outDir": "dist",
     "alwaysStrict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- [x] Verified compatibility and non-breaking changes with the `example` project.

#### Description

This PR introduces dual module support for `kysely-d1`, enabling it to export as both ESM and CommonJS modules. This enhancement is in line with the current module strategy adopted by [`kysely`](https://github.com/kysely-org/kysely/blob/03873201d5fe4e2e97227d89ff74bfe502160696/package.json#L12-L39). 

#### Before and After Impact

Previously, when importing `kysely-d1` alongside `kysely` in a project that prefers ESM, `kysely-d1` would still import the CJS version of `kysely`, leading to inefficiencies and a larger bundle size. The dependency tree prior to this change is illustrated below:

<image width="506px" alt="Before ESM and CJS Support" src="https://github.com/aidenwallis/kysely-d1/assets/6363984/478140af-7979-4d44-8d6b-c15384a910f9" />

With the introduction of both ESM and CJS exports, projects can now import the ESM version of `kysely`, optimizing the bundle size and improving loading times. The updated dependency tree, showcasing the more efficient structure, is shown here:

<image width="477" alt="After ESM and CJS Support" src="https://github.com/aidenwallis/kysely-d1/assets/6363984/b26ccfd4-03bc-4f81-b9de-930e779e43f5" />

This change has led to a 60% reduction in the size of `kysely` within the bundle, decreasing from 286KB to 114KB.
